### PR TITLE
Allow adding process specific env

### DIFF
--- a/lib/sidekiq_manager/capistrano/tasks/monit.rake
+++ b/lib/sidekiq_manager/capistrano/tasks/monit.rake
@@ -88,6 +88,13 @@ namespace :sidekiq do
       end
     end
 
+    def sidekiq_process_env(idx)
+      env = sidekiq_options_per_process[idx].fetch(:env, {})
+      env.map do |k, v|
+        "#{k.upcase}=#{v}"
+      end.join(" ")
+    end
+
     def sidekiq_service_name(index = nil)
       fetch(:sidekiq_service_name, "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}") + index.to_s
     end

--- a/lib/sidekiq_manager/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
+++ b/lib/sidekiq_manager/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
@@ -2,7 +2,7 @@
 <% processes_pids.each_with_index do |pid_file, idx| %>
 check process <%= sidekiq_service_name(idx) %>
   with pidfile "<%= pid_file %>"
-  start program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiq] %> <%= sidekiq_config %> --index <%= idx %> --pidfile <%= pid_file %> --environment <%= fetch(:sidekiq_env) %> <%= sidekiq_concurrency %> <%= sidekiq_logfile %> <%= sidekiq_require %> <%= sidekiq_queues %> <%= sidekiq_options_per_process[idx][:args] %> -d'" with timeout 30 seconds
+  start program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= sidekiq_process_env(idx) %> <%= SSHKit.config.command_map[:sidekiq] %> <%= sidekiq_config %> --index <%= idx %> --pidfile <%= pid_file %> --environment <%= fetch(:sidekiq_env) %> <%= sidekiq_concurrency %> <%= sidekiq_logfile %> <%= sidekiq_require %> <%= sidekiq_queues %> <%= sidekiq_options_per_process[idx][:args] %> -d'" with timeout 30 seconds
 
   stop program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiqctl] %> stop <%= pid_file %>'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
   group <%= fetch(:sidekiq_monit_group, fetch(:application)) %>-sidekiq


### PR DESCRIPTION
Allow passing env to sidekiq_options_per_process

```
set :sidekiq_options_per_process, [
  {
    pid_label: 'pid',
    env: { key: 'val' }
  }
]
```